### PR TITLE
disable current documentation build script.

### DIFF
--- a/deploy.Jenkinsfile
+++ b/deploy.Jenkinsfile
@@ -8,7 +8,7 @@ def release_id_description = (
     "  PIPELINE_NAME, BUILD_NUMBER;\n" +
     "           ...\n" +
     "With a comma separating job name and build number and a semi-colon " +
-    "separating entries, whitespace is ignored.")
+    "separating entries, white-space is ignored.")
 
 def get_agent() {
   def agent_label = ''
@@ -119,7 +119,7 @@ pipeline {
                                 variable: 'api_token')]) {
           powershell """
             \$artifacts = (Get-ChildItem -Filter ${repo_name}-*).Name
-
+            
             ./pwsh/Deploy-ToGitHub \
                 -AssetPaths \$artifacts \
                 -AuthToken \${env:api_token} \
@@ -141,14 +141,14 @@ pipeline {
         withCredentials([string(credentialsId: 'GitHub_API_Token',
                                 variable: 'api_token')]) {
           // Creates version's docs folder on gh-pages
-          powershell """
-            ./pwsh/Docs -Action "push" \
-                        -ReleaseName "${version_number}" \
-                        -AuthToken \${env:api_token}
-            ./pwsh/Docs -Action "update-stable" \
-                        -ReleaseName ${version_number} \
-                        -AuthToken \${env:api_token}
-            """
+          //powershell """
+          //  ./pwsh/Docs -Action "push" \
+          //              -ReleaseName "${version_number}" \
+          //              -AuthToken \${env:api_token}
+          //  ./pwsh/Docs -Action "update-stable" \
+          //              -ReleaseName ${version_number} \
+          //              -AuthToken \${env:api_token}
+          //  """
 
         }
       }


### PR DESCRIPTION
Fixes Re #6.  This is simplest solution to failure. No changes to documentation are done by the modified script as the code which does this is commented. Now, when the documentation is build by github actions this is probably reasonable solution.

GithubActions which build release documentation should be fixed by another ticket but this is minor issue as current documentaiton is updated on merge to master anyway.